### PR TITLE
Make it more threadsafe.

### DIFF
--- a/pickle.cabal
+++ b/pickle.cabal
@@ -26,6 +26,7 @@ library
   build-depends:        base ^>=4.12.0.0
                       , containers >= 0.6.0.1 && < 0.6.3
                       , network >= 2.8.0.0 && < 3.2
+                      , stm >= 2.4 && < 2.6
                       , text >= 1.2.3.1 && < 1.3
 
   -- Directories containing source files.


### PR DESCRIPTION
This makes some threadsafety improvements. `withPickleDo` had somewhat funky semantics; other threads could access the global connection even if they weren't forked from `withPickleDo`'s argument IO action, but they'd lose access once that action finishes. `withPickleDo` could be nested, but nested calls would also affect threads forked from the parent call, since there's still just one global connection.

This provides a `setupPickle` function that sets up the global connection. There's no nesting necessary since there's only one context to begin with. If it's desirable to nest things with different configurations, using [reflection](http://hackage.haskell.org/package/reflection-2.1.5/docs/Data-Reflection.html) is probably the most ergonomic way.

Calls to `metric` no longer block the caller or eachother. `send` should be atomic for datagram sockets anyway.